### PR TITLE
Form processor needs to be added to home page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -153,7 +153,7 @@ disqusShortname = ""
     # - send a dummy email yourself to confirm your account
     # - click the confirm link in the email from www.formspree.io
     # - you're done. Happy mailing!
-    # formEmail = "example@domain.com"
+    formEmail = "f/xeqplnoz"
 
     # Contact Section
     # You can add multiple emails, phone numbers, or addresses


### PR DESCRIPTION
Fixes #1

Internal documentation on the config.toml file is out dated. formspree has changed their limits and now uses a url path instead of the email address